### PR TITLE
feat: improve card layout and date format in blog page

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -37,13 +37,19 @@ export default function Page() {
               key={page.slugs.join('/')}
               href={`/blog/${page.slugs.join('/')}`}
               className="flex flex-col bg-white/80 backdrop-blur-sm rounded-2xl border shadow-sm p-4 transition-colors hover:bg-accent hover:text-accent-foreground hover:shadow-lg"
+              aria-label={`Read ${page.data.title}${page.data.date ? ` - Published ${new Date(page.data.date).toLocaleDateString()}` : ''}`}
             >
               <p className="font-medium">{page.data.title}</p>
+              {page.data.description && (
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {page.data.description}
+                </p>
+              )}
 
               {page.data.date && (
-                <p className="mt-auto pt-4 text-xs text-[color:var(--casbin-purple)]">
-                  {new Date(page.data.date).toDateString()}
-                </p>
+                <time dateTime={new Date(page.data.date).toISOString()} className="mt-auto pt-4 text-xs text-[color:var(--brand-primary)]">
+                  {new Date(page.data.date).toLocaleDateString()}
+                </time>
               )}
             </Link>
           ))}

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -48,7 +48,7 @@
 
 :root {
   --radius: 0.625rem;
-  --casbin-purple: #443D80;
+  --brand-primary: #443D80;
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);

--- a/src/components/blog/AuthorCard.tsx
+++ b/src/components/blog/AuthorCard.tsx
@@ -1,6 +1,3 @@
-"use client"
-
-import * as React from "react"
 import Link from "next/link"
 
 interface AuthorCardProps {
@@ -26,7 +23,7 @@ export function AuthorCard({ author, authorURL, date }: AuthorCardProps) {
       {formattedDate && (
         <div>
           <p className="mb-1 text-sm text-muted-foreground">At</p>
-          <time className="font-medium">{formattedDate}</time>
+          <time dateTime={date} className="font-medium">{formattedDate}</time>
         </div>
       )}
     </div>


### PR DESCRIPTION
Blog pages
- Make the entire card clickable to navigate to the corresponding blog post.
- Display the publish date at the bottom-left of the card, styled with the theme color #443D80.